### PR TITLE
Setting correct python version (python3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ python monasca api implementation
 =================================
 
 To install the python api implementation, git clone the source and run the
-following command::
+following command using python3::
 
-    sudo python setup.py install
+    sudo python3 setup.py install
 
 If it installs successfully, you will need to make changes to the following
 two files to reflect your system settings, especially where kafka server is


### PR DESCRIPTION
If you use python 2.x to run setup.python appear errors like:

> 
> UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode
> ascii' codec can't decode byte 0xc3

Setting to use python3 prevent this type of error.