### PR TITLE
Fix Monasca tempest tests README file

### DIFF
--- a/monasca_tempest_tests/README.md
+++ b/monasca_tempest_tests/README.md
@@ -32,17 +32,17 @@ Currently the devstack environment is needed to run the tests. Instructions on s
    ```
     [identity]
 
-username = mini-mon
-password = password
-tenant_name = mini-mon
-domain_name = Default
-alt_username = mini-mon
-alt_password = password
-alt_tenant_name = mini-mon
-use_ssl = False
-auth_version = v3
-uri = http://127.0.0.1:5000/v2.0/
-uri_v3 = http://127.0.0.1:35357/v3/
+    username = mini-mon
+    password = password
+    tenant_name = mini-mon
+    domain_name = Default
+    alt_username = mini-mon
+    alt_password = password
+    alt_tenant_name = mini-mon
+    use_ssl = False
+    auth_version = v3
+    uri = http://127.0.0.1:5000/v2.0/
+    uri_v3 = http://127.0.0.1:35357/v3/
 
     [auth]
 


### PR DESCRIPTION
Fixes `tempest.conf` section in Monasca Tempest Tests README file