### PR TITLE
monasca api add support for cassandra

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ ARG CONSTRAINTS_BRANCH=master
 # Extra Python3 dependencies.
 # gevent is not in upper constrains and v1.3.6 is not working with
 # older greenlet.
-ARG EXTRA_DEPS="gunicorn gevent==1.3.5 python-memcached influxdb"
+ARG EXTRA_DEPS="gunicorn gevent==1.3.5 python-memcached influxdb cassandra"
 
 # Always start from `monasca-base` image and use specific tag of it.
 ARG BASE_TAG=master


### PR DESCRIPTION
I found that when use cassandra for monasca storage, api call error No module named 'cassandra'